### PR TITLE
chore: revert `engines.node`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,4 +14,7 @@
 			enabled: false,
 		},
 	],
+  "ignoreDeps": [
+    "node",
+  ],
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
   },
   "packageManager": "pnpm@10.5.2",
   "engines": {
-    "node": ">=18.20.7"
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
The `engines.node` has been bumped to `18.20.7` in #4, which is a **BREAKING CHANGE**.

In this patch, we reverted it back to `18`. And also disable the update of `node` in Renovate.