### PR TITLE
chore: release v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typia-rspack-plugin",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "A plugin for Rspack to use Typia.",
   "keywords": [
     "rspack",


### PR DESCRIPTION
> [!IMPORTANT]
> This is a breaking change since we have upgraded to unplugin-typia v2 which requires typia@8. 

See: #10 