### PR TITLE
chore: apply pnpm better defaults

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,18 @@
+enableGlobalVirtualStore: true
+
+enablePrePostScripts: false
+
+ignorePatchFailures: false
+
 ignoredBuiltDependencies:
   - core-js
+  - esbuild
+
 onlyBuiltDependencies:
   - dprint
+
+optimisticRepeatInstall: true
+
+resolutionMode: lowest-direct
+
+verifyDepsBeforeRun: install


### PR DESCRIPTION
We didn't use `@pnpm/plugin-better-defaults` in `configDependencies` since it would break Renovate.

See: https://github.com/renovatebot/renovate/discussions/37101