### PR TITLE
[codex] remove unused @samchon/openapi dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@microsoft/api-extractor": "^7.58.7",
     "@rslib/core": "^0.21.3",
     "@ryoppippi/unplugin-typia": "^2.6.5",
-    "@samchon/openapi": "^4.7.2",
     "@types/node": "^24.12.2",
     "dprint": "^0.54.0",
     "rsbuild-plugin-publint": "^0.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,9 +21,6 @@ importers:
       '@ryoppippi/unplugin-typia':
         specifier: ^2.6.5
         version: 2.6.5(rollup@4.34.1)(typescript@6.0.3)(typia@12.0.2(typescript@6.0.3))(vite@6.0.11(@types/node@24.12.2)(jiti@2.6.1)(terser@5.37.0))
-      '@samchon/openapi':
-        specifier: ^4.7.2
-        version: 4.7.2
       '@types/node':
         specifier: ^24.12.2
         version: 24.12.2
@@ -620,9 +617,6 @@ packages:
         optional: true
       vite:
         optional: true
-
-  '@samchon/openapi@4.7.2':
-    resolution: {integrity: sha512-yj6kGWHtKK85wfJXrSmWqLWjfCd98SAvCTsVDlej2s7OfXXHqA4hmgPRNrAPIQRVi00xn26qL1PChjq1MhzlRQ==}
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
@@ -1678,8 +1672,6 @@ snapshots:
       vite: 6.0.11(@types/node@24.12.2)(jiti@2.6.1)(terser@5.37.0)
     transitivePeerDependencies:
       - rollup
-
-  '@samchon/openapi@4.7.2': {}
 
   '@standard-schema/spec@1.0.0': {}
 


### PR DESCRIPTION
## What changed

Removed the unused `@samchon/openapi` dev dependency from `package.json` and pruned its entries from `pnpm-lock.yaml`.

## Why

The package no longer has any source references in this repository, so keeping it in the install set only adds unnecessary dependency weight.

## Impact

Installs no longer fetch `@samchon/openapi` for this package. Runtime and build output are unchanged.

## Validation

- `pnpm install --frozen-lockfile`
- `rg -n "@samchon/openapi|samchon/openapi" package.json pnpm-lock.yaml src` returned no matches
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused development dependency to streamline the project setup.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/colinaaa/typia-rspack-plugin/pull/45)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->