### PR TITLE
chore: migrate to npm staged publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          registry-url: https://registry.npmjs.org
 
       - name: Setup Package Managers
         run: |
@@ -40,6 +41,4 @@ jobs:
         run: pnpm build
 
       - name: Publish
-        uses: JS-DevTools/npm-publish@v4
-        with:
-          token: empty
+        run: pnpm stage publish --no-git-checks


### PR DESCRIPTION
Migrate release workflow from `JS-DevTools/npm-publish` to npm staged publishing.

## Changes

- Replace `JS-DevTools/npm-publish@v4` with `pnpm stage publish --no-git-checks`
- Add `registry-url` to `setup-node` for OIDC token exchange

## How it works

CI stages the package on tag push. A maintainer then approves it with 2FA on [npmjs.com](https://npmjs.com) or via `npm stage approve`.

Ref: https://docs.npmjs.com/staged-publishing