### PR TITLE
feat: enable dts.isolated for faster builds

### DIFF
--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     {
       format: "esm",
       syntax: "es2023",
-      dts: { bundle: true },
+      dts: { bundle: true, isolated: true },
       source: {
         entry: {
           index: "./src/index.ts",

--- a/src/options.ts
+++ b/src/options.ts
@@ -39,5 +39,5 @@ export type Options = {
 
 export type LoaderOptions = Pick<Options, "tsconfig" | "typia">;
 
-export const DEFAULT_INCLUDE = [/\.[cm]?[jt]sx?$/];
-export const DEFAULT_EXCLUDE = [/node_modules/];
+export const DEFAULT_INCLUDE: readonly RegExp[] = [/\.[cm]?[jt]sx?$/];
+export const DEFAULT_EXCLUDE: readonly RegExp[] = [/node_modules/];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "strict": true,
     "skipLibCheck": true,
     "isolatedModules": true,
+    "isolatedDeclarations": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "useDefineForClassFields": true,


### PR DESCRIPTION
## Summary

Enable `dts.isolated: true` in rslib config to use SWC-based isolated declarations for DTS generation instead of tsc.

## Changes

- Set `dts: { bundle: true, isolated: true }` in `rslib.config.ts`
- Add explicit type annotations to exported arrays in `src/options.ts` (required by `isolatedDeclarations`)

## Benchmark

```
hyperfine --runs 5 "node --run build" --warmup 3
```

| Mode | Mean ± σ |
|------|----------|
| `isolated: false` | 1.897s ± 0.069s |
| `isolated: true` | **1.233s ± 0.014s** |

**~35% faster builds** with lower variance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build configuration for enhanced type declaration generation.
  * Strengthened type safety for library constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->