### PR TITLE
fix: resolve relative string paths in include/exclude options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import type { Compiler } from "@rspack/core";
+import { resolve } from "node:path";
+import process from "node:process";
 import { fileURLToPath } from "node:url";
-import { DEFAULT_EXCLUDE, DEFAULT_INCLUDE, type LoaderOptions, type Options } from "./options.js";
+import { DEFAULT_EXCLUDE, DEFAULT_INCLUDE, type LoaderOptions, type Options, type RuleCondition } from "./options.js";
 
 class TypiaRspackPlugin {
   #options: Options;
@@ -16,14 +18,28 @@ class TypiaRspackPlugin {
       typia: options.typia,
     };
 
+    const context = compiler.context ?? process.cwd();
+
     compiler.options.module.rules.push({
       enforce: options.enforce ?? "pre",
-      exclude: options.exclude ?? DEFAULT_EXCLUDE,
+      exclude: resolveCondition(options.exclude ?? DEFAULT_EXCLUDE, context),
       loader: fileURLToPath(new URL("./loader.js", import.meta.url)),
       options: loaderOptions,
-      test: options.include ?? DEFAULT_INCLUDE,
+      test: resolveCondition(options.include ?? DEFAULT_INCLUDE, context),
     });
   }
+}
+
+function resolveCondition(condition: RuleCondition, context: string): RuleCondition {
+  if (typeof condition === "string") {
+    return resolve(context, condition);
+  }
+
+  if (Array.isArray(condition)) {
+    return condition.map((c) => resolveCondition(c, context));
+  }
+
+  return condition;
 }
 
 export type { Options };

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,6 @@
 import type { transform as typiaTransform } from "typia/lib/transform";
 
-type RuleCondition = string | RegExp | ((value: string) => boolean) | RuleCondition[];
+export type RuleCondition = string | RegExp | ((value: string) => boolean) | RuleCondition[];
 
 type TypiaOptions = Parameters<typeof typiaTransform>[1];
 

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
+import { TypiaRspackPlugin } from "../src/index";
 import { formatDiagnostic, transformTypia } from "../src/transform";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -123,4 +124,35 @@ test("formats diagnostics with message fallback when line lookup fails", () => {
   };
 
   expect(formatDiagnostic(diagnostic)).toBe("'}' expected.");
+});
+
+test("resolves relative string include paths against compiler context", () => {
+  const rules: Array<{ test?: unknown }> = [];
+  const fakeCompiler = {
+    context: "/projects/my-app",
+    options: { module: { rules } },
+  };
+
+  const plugin = new TypiaRspackPlugin({ include: "./src/validate.ts" });
+
+  plugin.apply(fakeCompiler as any);
+
+  expect(rules).toHaveLength(1);
+  expect(rules[0]!.test).toBe(resolve("/projects/my-app", "./src/validate.ts"));
+});
+
+test("preserves RegExp include without modification", () => {
+  const rules: Array<{ test?: unknown }> = [];
+  const fakeCompiler = {
+    context: "/projects/my-app",
+    options: { module: { rules } },
+  };
+  const pattern = /\.tsx?$/;
+
+  const plugin = new TypiaRspackPlugin({ include: pattern });
+
+  plugin.apply(fakeCompiler as any);
+
+  expect(rules).toHaveLength(1);
+  expect(rules[0]!.test).toBe(pattern);
 });


### PR DESCRIPTION
## Problem

When `include` is a relative path string (e.g. `'./src/config/validate.ts'`), the v3.0.0 plugin passes it directly as rspack's rule `test` field. Rspack matches `test` against each module's absolute `resourcePath`, so a relative path never matches — causing typia transforms to silently not run.

This broke https://github.com/lynx-family/lynx-stack/pull/2761 (`test-publish` CI failure):

```
Error on typia.createValidateEquals(): no transform has been configured.
```

## Root Cause

In v2 (unplugin-typia), relative paths were resolved internally by unplugin's filter/picomatch. The v3 rewrite passes `include`/`exclude` directly to rspack rules without resolving, breaking consumers that pass relative strings.

## Fix

Resolve string `include`/`exclude` values against `compiler.context` before passing them to the rule config. RegExp and function conditions are passed through unchanged.